### PR TITLE
bugfix: prevent scrolling when touching & drawing on the canvas

### DIFF
--- a/public/lib/core.ts
+++ b/public/lib/core.ts
@@ -147,6 +147,23 @@ export class Application {
             this.onfocuschanged.invoke(false);
         });
 
+        // Prevent scrolling when touching the canvas
+        this.graphics.canvas.addEventListener("touchstart", function (e) {
+            if (e.target == canvas) {
+            e.preventDefault();
+            }
+        }, false);
+        this.graphics.canvas.addEventListener("touchend", function (e) {
+            if (e.target == canvas) {
+            e.preventDefault();
+            }
+        }, false);
+        this.graphics.canvas.addEventListener("touchmove", function (e) {
+            if (e.target == canvas) {
+            e.preventDefault();
+            }
+        }, false);
+
         const onPointerDown = (x : number, y : number, button : number, touches : TouchList | Touch[]) => {
             this.pointer.px = this.pointer.x = x;
             this.pointer.py = this.pointer.y = y;


### PR DESCRIPTION
The added touch support was nearly perfect. Touch and Stylus now was recognised by the canvas.
However the window also tried to scroll on the touch event. I managed to replicate this without using a tablet via Chrome's Dev Tools and emulating an iPad Pro.

After a quick bit of googling I found the same situation described here : http://bencentra.com/code/2014/12/05/html5-canvas-touch-events.html#touch-input 

Implemented a bug fix as per the example code on that site and it fixed the issue.  